### PR TITLE
added custom command options to msg

### DIFF
--- a/msg/MissionCommand.msg
+++ b/msg/MissionCommand.msg
@@ -2,7 +2,9 @@ uint8 MISSION_START=1
 uint8 MISSION_END=2
 uint8 CHANGE_PARAMS=3
 uint8 REPORT_PROGRESS=4
+uint8 CUSTOM_COMMAND=99
 
 builtin_interfaces/Time stamp
 uint8 command
 string[] args
+string custom_command_func 


### PR DESCRIPTION
This PR proposes a custom command option to avoid adding multiple specific commands to the generic mission_msgs.
